### PR TITLE
orthw: Remove jq from required commands

### DIFF
--- a/orthw
+++ b/orthw
@@ -3,7 +3,7 @@
 ########################################
 # Required configuration:
 #
-required_commands="curl jq md5sum xz"
+required_commands="curl md5sum xz"
 required_directories="configuration_home ort_home orthw_home scancode_home exports_home"
 
 


### PR DESCRIPTION
The `jq` tool was used by a `orthw` command that was removed
so we should not require `jq` to be installed on user system.
