### PR TITLE
orthw: Fix an issue with the "offending-licenses" command

### DIFF
--- a/orthw
+++ b/orthw
@@ -706,7 +706,7 @@ if [ "$command" = "offending-licenses" ] && [ "$#" -eq 2 ]; then
   $orth list-licenses \
     --ort-file $evaluation_result_file \
     --package-id $package_id \
-    --ignore-excluded-rule-ids $ignore_excluded_rule_ids \
+    --ignore-excluded-rule-ids "$ignore_excluded_rule_ids" \
     --repository-configuration-file $repository_configuration_file \
     --package-configuration-dir $ort_config_package_configuration_dir \
     --apply-license-finding-curations \
@@ -726,7 +726,7 @@ if [ "$command" = "offending-licenses" ] && [ "$#" -eq 3 ]; then
   $orth list-licenses \
     --ort-file $evaluation_result_file \
     --package-id $package_id \
-    --ignore-excluded-rule-ids $ignore_excluded_rule_ids \
+    --ignore-excluded-rule-ids "$ignore_excluded_rule_ids" \
     --repository-configuration-file $repository_configuration_file \
     --package-configuration-dir $ort_config_package_configuration_dir \
     --source-code-dir $source_code_dir \


### PR DESCRIPTION
If the value of `ignore_excluded_rule_ids` is an empty string, which is
the default value in the configuration, then the call to `orth` exits
with [1]. So, add quotes to fix that.

[1] Error: Got unexpected extra argument (ort.yml)
