### PR TITLE
orthw: Fix the broken `check_evaluation_md5_sum()`

### DIFF
--- a/orthw
+++ b/orthw
@@ -223,6 +223,7 @@ get_package_curations_dir_md5_sum() {
 check_evaluation_md5_sum() {
   if [ -f $evaluation_md5_sum_file ]; then
     get_package_configuration_dir_md5_sum > $package_configuration_md5_sum_file
+    get_package_curations_dir_md5_sum > $package_curations_md5_sum_file
     md5sum -c $evaluation_md5_sum_file > /dev/null 2>&1
     echo $?
     rm -f $package_configuration_md5_sum_file


### PR DESCRIPTION
The MD5 checksum of the package curations was properly handled in
`update_evaluation_md5_sum()` but missing in
`check_evaluation_md5_sum()`. So, when recomputing the report after
making a file change in the package curations directory the evaluator
was not re-run. Add the missing check, analog to the one for package
configurations, to fix that problem.

Fixes #19.