### PR TITLE
orthw: Gracfully handle the exit code of the evalutor

### DIFF
--- a/orthw
+++ b/orthw
@@ -286,9 +286,12 @@ evaluate() {
     --rules-file $ort_config_rules_file \
     --license-classifications-file $ort_config_license_classifications_file \
     --package-configuration-dir $ort_config_package_configuration_dir
-  # Ideally the md5 sums should only be updated in case evaluate successfully.
-  # completes, but unfortunately the return code cannot be used as indicator.
-  # TODO: Fix the exit code of the evaluator.
+
+  if [[ $? -eq "1" ]]; then
+    echo "Error running the evaluator."
+    exit 1
+  fi
+
   update_evaluation_md5_sum
   mv "$temp_dir/evaluation-result.json" $evaluation_result_file
 


### PR DESCRIPTION
ORT's evaluator may return the following exit codes:

`0`: The execution was successful and no severe issues have been found.
`1`: The execution failed.
`2`: The execution succeeded and severe issues have been found.

`orthw` uses an MD5 sum file for checking whether the evaluator needs to
be (re-)run, e.g. inputs have changed. So, don't update the MD5 sums in
case the evaluation fails to ensure the evaluator is run in the next
attempt to generate a report.

Fixes #15.