### PR TITLE
Allow for configuring CLI options for `ort` and `orth`

### DIFF
--- a/orthw
+++ b/orthw
@@ -152,11 +152,10 @@ usage() {
   echo ""
 }
 
-
 analyze() {
   local source_code_dir=$(realpath "$1")
 
-  $ort analyze \
+  ort analyze \
     --input-dir $source_code_dir \
     --output-dir . \
     --output-formats JSON \
@@ -214,7 +213,7 @@ analyze_in_docker() {
 advise() {
   mkdir -p $temp_dir
 
-  $ort advise \
+  ort advise \
     --advisors "$enabled_advisors" \
     --output-dir $temp_dir \
     --output-formats JSON \
@@ -276,7 +275,7 @@ evaluate() {
 
   mkdir -p $temp_dir
 
-  $ort evaluate \
+  ort evaluate \
     --copyright-garbage-file $ort_config_copyright_garbage_file \
     --package-curations-dir $ort_config_package_curations_dir \
     --output-dir $temp_dir \
@@ -340,6 +339,10 @@ list_scan_results() {
   echo "$result"
 }
 
+ort() {
+  $ort "$@"
+}
+
 query_scandb() {
   local sql=$1
   require_command "psql"
@@ -360,7 +363,7 @@ report() {
     notice_template_path_option="-O NoticeTemplate=template.path=$notice_template_files"
   fi
 
-  $ort report \
+  ort report \
     --copyright-garbage-file $ort_config_copyright_garbage_file \
     --custom-license-texts-dir $ort_config_custom_license_texts_dir \
     --how-to-fix-text-provider-script $ort_config_how_to_fix_text_provider_script \

--- a/orthw
+++ b/orthw
@@ -342,13 +342,13 @@ list_scan_results() {
 ort() {
   export ORT_OPTS="$ort_jvm_options"
 
-  $ort "$@"
+  $ort $ort_options "$@"
 }
 
 orth() {
   export ORTH_OPTS="$orth_jvm_options"
 
-  $orth "$@"
+  $orth $orth_options "$@"
 }
 
 query_scandb() {

--- a/orthw
+++ b/orthw
@@ -322,7 +322,7 @@ find_license_text_url() {
 find_package_configuration() {
   local package_id=$1
 
-  $orth package-configuration find \
+  orth package-configuration find \
     --package-configuration-dir $ort_config_package_configuration_dir \
     --package-id $package_id
 }
@@ -341,6 +341,10 @@ list_scan_results() {
 
 ort() {
   $ort "$@"
+}
+
+orth() {
+  $orth "$@"
 }
 
 query_scandb() {
@@ -472,7 +476,7 @@ fi
 if [ "$command" = "create-analyzer-result" ] && [ "$#" -eq 2 ]; then
   package_ids_file=$2
 
-  $orth create-analyzer-result \
+  orth create-analyzer-result \
     --package-ids-file $package_ids_file \
     --scancode-version "$scancode_version" \
     -P "ort.scanner.storages.postgres.url=jdbc:postgresql://$scandb_host:$scandb_port/$scandb_db" \
@@ -489,13 +493,13 @@ fi
 if [ "$command" = "copyrights" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth list-copyrights \
+  orth list-copyrights \
     --ort-file $scan_result_file \
     --package-configuration-dir $ort_config_package_configuration_dir \
     --copyright-garbage-file $ort_config_copyright_garbage_file \
     > $copyrights_file
 
-  $orth list-copyrights \
+  orth list-copyrights \
     --ort-file $scan_result_file \
     --package-configuration-dir $ort_config_package_configuration_dir \
     --copyright-garbage-file $ort_config_copyright_garbage_file \
@@ -511,7 +515,7 @@ if [ "$command" = "copyrights" ] && [ "$#" -eq 2 ]; then
   package_id=$2
   require_initialized
 
-  $orth list-copyrights \
+  orth list-copyrights \
     --ort-file $scan_result_file \
     --package-id $package_id
 
@@ -583,7 +587,7 @@ if [ "$command" = "export-copyright-garbage" ] && [ "$#" -eq 1 ]; then
 
   mapped_copyrights_file="$temp_dir/copyrights-mapped.txt"
   mkdir -p $temp_dir
-  $orth map-copyrights\
+  orth map-copyrights\
     --input-copyrights-file $copyrights_file \
     --output-copyrights-file $mapped_copyrights_file \
     --ort-file $scan_result_file
@@ -591,7 +595,7 @@ if [ "$command" = "export-copyright-garbage" ] && [ "$#" -eq 1 ]; then
   echo ""
   cat "$mapped_copyrights_file"
   echo ""
-  $orth import-copyright-garbage \
+  orth import-copyright-garbage \
     --input-copyright-garbage-file $mapped_copyrights_file \
     --output-copyright-garbage-file $ort_config_copyright_garbage_file
   rm -rf $temp_dir
@@ -624,14 +628,14 @@ fi
 
 
 if [ "$command" = "handled-licenses" ] && [ "$#" -eq 1 ]; then
-  $orth list-license-categories \
+  orth list-license-categories \
     --license-classifications-file $ort_config_license_classifications_file
   exit 0
 fi
 
 
 if [ "$command" = "handled-licenses-by-category" ] && [ "$#" -eq 1 ]; then
-  $orth list-license-categories \
+  orth list-license-categories \
     --license-classifications-file $ort_config_license_classifications_file \
     --group-by-category
   exit 0
@@ -669,11 +673,11 @@ if [ "$command" = "init" ] && [ "$#" -eq 2 ]; then
   fi
   mv $temp_scan_result_file $scan_result_file
 
-  $orth extract-repository-configuration \
+  orth extract-repository-configuration \
     --repository-configuration-file $repository_configuration_file \
     --ort-file $scan_result_file
 
-  $orth import-scan-results \
+  orth import-scan-results \
     --ort-file $scan_result_file \
     --scan-results-storage-dir $scan_results_storage_dir
 
@@ -687,7 +691,7 @@ if [ "$command" = "licenses" ] && [ "$#" -eq 2 ]; then
 
   evaluate
   echo "Downloading sources for $2."
-  $orth list-licenses \
+  orth list-licenses \
     --ort-file $evaluation_result_file \
     --package-id $package_id \
     --repository-configuration-file $repository_configuration_file \
@@ -704,7 +708,7 @@ if [ "$command" = "licenses" ] && [ "$#" -eq 3 ]; then
   require_initialized
 
   evaluate
-  $orth list-licenses \
+  orth list-licenses \
     --ort-file $evaluation_result_file \
     --package-id $package_id \
     --repository-configuration-file $repository_configuration_file \
@@ -722,7 +726,7 @@ if [ "$command" = "offending-licenses" ] && [ "$#" -eq 2 ]; then
 
   evaluate
   echo "Downloading sources for $2."
-  $orth list-licenses \
+  orth list-licenses \
     --ort-file $evaluation_result_file \
     --package-id $package_id \
     --ignore-excluded-rule-ids "$ignore_excluded_rule_ids" \
@@ -742,7 +746,7 @@ if [ "$command" = "offending-licenses" ] && [ "$#" -eq 3 ]; then
   require_initialized
 
   evaluate
-  $orth list-licenses \
+  orth list-licenses \
     --ort-file $evaluation_result_file \
     --package-id $package_id \
     --ignore-excluded-rule-ids "$ignore_excluded_rule_ids" \
@@ -759,7 +763,7 @@ fi
 
 if [ "$command" = "packages" ] && [ "$#" -eq 1 ]; then
   require_initialized
-  $orth list-packages --ort-file $scan_result_file
+  orth list-packages --ort-file $scan_result_file
   exit 0
 fi
 
@@ -768,7 +772,7 @@ if [ "$command" = "packages-for-detected-licenses" ] && [ "$#" -eq 2 ]; then
   detected_licenses=$2
   require_initialized
 
-  $orth list-packages \
+  orth list-packages \
     --ort-file $scan_result_file \
     --match-detected-licenses $detected_licenses
   exit 0
@@ -779,7 +783,7 @@ if [ "$command" = "pc-create" ] && [ "$#" -eq 2 ]; then
   require_initialized
 
   package_id=$2
-  $orth package-configuration create \
+  orth package-configuration create \
     --scan-results-storage-dir $scan_results_storage_dir \
     --package-id $package_id \
     --create-hierarchical-dirs \
@@ -794,7 +798,7 @@ if [ "$command" = "pc-clean" ] && [ "$#" -eq 2 ]; then
 
   package_configuration_file=$(find_package_configuration $package_id)
 
-  $orth package-configuration remove-entries \
+  orth package-configuration remove-entries \
     --package-configuration-file $package_configuration_file \
     --ort-file $scan_result_file
 
@@ -808,7 +812,7 @@ if [ "$command" = "pc-export-curations" ] && [ "$#" -eq 3 ]; then
 
   package_configuration_file=$(find_package_configuration $package_id)
 
-  $orth package-configuration export-license-finding-curations \
+  orth package-configuration export-license-finding-curations \
     --package-configuration-file $package_configuration_file \
     --license-finding-curations-file $exports_license_finding_curations_file \
     --source-code-dir $source_code_dir \
@@ -824,7 +828,7 @@ if [ "$command" = "pc-export-path-excludes" ] && [ "$#" -eq 3 ]; then
 
   package_configuration_file=$(find_package_configuration $package_id)
 
-  $orth package-configuration export-path-excludes \
+  orth package-configuration export-path-excludes \
     --package-configuration-file $package_configuration_file \
     --path-excludes-file $exports_path_excludes_file \
     --source-code-dir $source_code_dir \
@@ -848,7 +852,7 @@ if [ "$command" = "pc-format" ] && [ "$#" -eq 2 ]; then
 
   package_configuration_file=$(find_package_configuration $package_id)
 
-  $orth package-configuration format $package_configuration_file
+  orth package-configuration format $package_configuration_file
 
   exit 0
 fi
@@ -861,7 +865,7 @@ if [ "$command" = "pc-import-curations" ] && [ "$#" -eq 3 ]; then
 
   package_configuration_file=$(find_package_configuration $package_id)
 
-  $orth package-configuration import-license-finding-curations \
+  orth package-configuration import-license-finding-curations \
     --package-configuration-file $package_configuration_file \
     --license-finding-curations-file $exports_license_finding_curations_file \
     --ort-file $scan_result_file \
@@ -877,7 +881,7 @@ if [ "$command" = "pc-import-path-excludes" ] && [ "$#" -eq 3 ]; then
 
   package_configuration_file=$(find_package_configuration $package_id)
 
-  $orth package-configuration import-path-excludes \
+  orth package-configuration import-path-excludes \
     --package-configuration-file $package_configuration_file \
     --path-excludes-file $exports_path_excludes_file \
     --source-code-dir $source_code_dir
@@ -891,7 +895,7 @@ if [ "$command" = "pc-sort" ] && [ "$#" -eq 2 ]; then
 
   package_configuration_file=$(find_package_configuration $package_id)
 
-  $orth package-configuration sort $package_configuration_file
+  orth package-configuration sort $package_configuration_file
 
   exit 0
 fi
@@ -901,13 +905,13 @@ if [ "$command" = "raw-licenses" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
   evaluate
-  package_ids=$($orth list-packages --ort-file $scan_result_file)
+  package_ids=$(orth list-packages --ort-file $scan_result_file)
   IFS='
   '
   for package_id in $package_ids
   do
     echo "Downloading sources for $package_id."
-    $orth list-licenses \
+    orth list-licenses \
       --ort-file $evaluation_result_file \
       --package-id $package_id \
       --repository-configuration-file $repository_configuration_file
@@ -922,7 +926,7 @@ if [ "$command" = "rc-clean" ] && [ "$#" -eq 2 ]; then
   require_initialized
   evaluate
 
-  $orth repository-configuration remove-entries \
+  orth repository-configuration remove-entries \
     --ort-file $evaluation_result_file \
     --repository-configuration-file $repository_configuration_file \
     --source-code-dir $source_code_dir \
@@ -934,7 +938,7 @@ fi
 if [ "$command" = "rc-export-curations" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration export-license-finding-curations \
+  orth repository-configuration export-license-finding-curations \
     --license-finding-curations-file $exports_license_finding_curations_file \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file \
@@ -946,7 +950,7 @@ fi
 if [ "$command" = "rc-export-path-excludes" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration export-path-excludes \
+  orth repository-configuration export-path-excludes \
     --path-excludes-file $exports_path_excludes_file \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file \
@@ -958,7 +962,7 @@ fi
 if [ "$command" = "rc-format" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration format $repository_configuration_file
+  orth repository-configuration format $repository_configuration_file
   exit 0
 fi
 
@@ -966,7 +970,7 @@ fi
 if [ "$command" = "rc-generate-project-excludes" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration generate-project-excludes \
+  orth repository-configuration generate-project-excludes \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file
   exit 0
@@ -976,7 +980,7 @@ fi
 if [ "$command" = "rc-generate-scope-excludes" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration generate-scope-excludes \
+  orth repository-configuration generate-scope-excludes \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file
   exit 0
@@ -987,7 +991,7 @@ if [ "$command" = "rc-generate-rule-violation-resolutions" ] && [ "$#" -eq 1 ]; 
   require_initialized
 
   evaluate
-  $orth repository-configuration generate-rule-violation-resolutions \
+  orth repository-configuration generate-rule-violation-resolutions \
     --ort-file $evaluation_result_file \
     --repository-configuration-file $repository_configuration_file \
     --severity ERROR
@@ -998,7 +1002,7 @@ fi
 if [ "$command" = "rc-generate-timeout-error-resolutions" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth generate-timeout-error-resolutions \
+  orth generate-timeout-error-resolutions \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file \
     --resolutions-file $ort_config_resolutions_file \
@@ -1010,7 +1014,7 @@ fi
 if [ "$command" = "rc-import-curations" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration import-license-finding-curations \
+  orth repository-configuration import-license-finding-curations \
     --license-finding-curations-file $exports_license_finding_curations_file \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file
@@ -1021,7 +1025,7 @@ fi
 if [ "$command" = "rc-import-curations-update-only" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration import-license-finding-curations \
+  orth repository-configuration import-license-finding-curations \
     --license-finding-curations-file $exports_license_finding_curations_file \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file \
@@ -1033,7 +1037,7 @@ fi
 if [ "$command" = "rc-import-path-excludes" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration import-path-excludes \
+  orth repository-configuration import-path-excludes \
     --path-excludes-file $exports_path_excludes_file \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file \
@@ -1045,7 +1049,7 @@ fi
 if [ "$command" = "rc-import-path-excludes-update-only" ] && [ "$#" -eq 1 ]; then
   require_initialized
 
-  $orth repository-configuration import-path-excludes \
+  orth repository-configuration import-path-excludes \
     --path-excludes-file $exports_path_excludes_file \
     --ort-file $scan_result_file \
     --repository-configuration-file $repository_configuration_file \
@@ -1057,7 +1061,7 @@ fi
 
 if [ "$command" = "rc-sort" ] && [ "$#" -eq 1 ]; then
   require_initialized
-  $orth repository-configuration sort $repository_configuration_file
+  orth repository-configuration sort $repository_configuration_file
   exit 0
 fi
 

--- a/orthw
+++ b/orthw
@@ -340,10 +340,14 @@ list_scan_results() {
 }
 
 ort() {
+  export ORT_OPTS="$ort_jvm_options"
+
   $ort "$@"
 }
 
 orth() {
+  export ORTH_OPTS="$orth_jvm_options"
+
   $orth "$@"
 }
 

--- a/orthw
+++ b/orthw
@@ -327,7 +327,6 @@ find_package_configuration() {
     --package-id $package_id
 }
 
-
 list_scan_results() {
   local package_id=$1
   # The package_id is parameter to the SQL LIKE operator, see https://www.postgresqltutorial.com/postgresql-like/.

--- a/orthwconfig-template
+++ b/orthwconfig-template
@@ -101,6 +101,15 @@ gitlab_host="gitlab.example.com"
 gitlab_token=""
 
 #
+# Options for ORT's CLI and helper CLI binaries, `ort` and `orthw`.
+# Please refer to the help instructions of the respective CLI binary for the full list of available options.
+#
+# The logging can be configured e.g. via "--info", "--debug" and "--stacktrace".
+#
+ort_options=""
+orth_options=""
+
+#
 # JVM options for ORT's CLI and helper CLI binaries, `ort` and `orth`.
 #
 ort_jvm_options="-Xmx16G"

--- a/orthwconfig-template
+++ b/orthwconfig-template
@@ -103,5 +103,5 @@ gitlab_token=""
 #
 # JVM options for ORT's CLI and helper CLI binaries, `ort` and `orth`.
 #
-export ORT_OPTS="-Xmx16G"
-export ORTH_OPTS="-Xmx16G"
+ort_jvm_options="-Xmx16G"
+orth_jvm_options="-Xmx16G"

--- a/orthwconfig-template
+++ b/orthwconfig-template
@@ -106,7 +106,7 @@ gitlab_token=""
 #
 # The logging can be configured e.g. via "--info", "--debug" and "--stacktrace".
 #
-ort_options=""
+ort_options="--info"
 orth_options=""
 
 #


### PR DESCRIPTION
This e.g. enables setting the log level from the configuration.

Note: User's must align their configuration file with these changes.