### PR TITLE
orthw: Gracefully handle missing configuration file

### DIFF
--- a/orthw
+++ b/orthw
@@ -6,10 +6,15 @@
 required_commands="curl md5sum xz"
 required_directories="configuration_home ort_home orthw_home scancode_home exports_home"
 
-
-orthw_config_file=~/.orthwconfig
-# shellcheck source=orthconfig-template
-. "$orthw_config_file"
+orthw_config_file="$HOME/.orthwconfig"
+if [ -f "$orthw_config_file" ]; then
+  # shellcheck source=orthconfig-template
+  . "$orthw_config_file"
+else
+  echo "Missing the required configuration file '$orthw_config_file'. Please create that file following the "
+  echo "installation instructions, see https://github.com/oss-review-toolkit/orthw#3-create-your-orthw-configuration."
+  exit 1
+fi
 
 ########################################
 # Executables:


### PR DESCRIPTION
In case the users hasn't setup a configuration file the script fails
with a non-informative error message [1]. Output an error message which
indicates what whent wrong and how to fix it.

Fixes https://github.com/oss-review-toolkit/orthw/issues/28.

[1] The variable 'configuration_home' must be defined in [...]