### PR TITLE
orthw: Enable path exclude generation for package configurations

### DIFF
--- a/orthw
+++ b/orthw
@@ -230,6 +230,18 @@ advise() {
   rm -rf $temp_dir
 }
 
+create_package_configuration() {
+  local package_id=$1
+
+  orth package-configuration create \
+      --scan-results-storage-dir $scan_results_storage_dir \
+      --package-id $package_id \
+      --create-hierarchical-dirs \
+      --generate-path-excludes \
+      --output-dir $ort_config_package_configuration_dir \
+      --force-overwrite
+}
+
 get_package_configuration_dir_md5_sum() {
   find $ort_config_package_configuration_dir -type f -name "*.yml" | sort | xargs md5sum | md5sum
 }
@@ -818,15 +830,10 @@ fi
 
 if [ "$command" = "pc-create" ] && [ "$#" -eq 2 ]; then
   require_initialized
-
   package_id=$2
-  orth package-configuration create \
-    --scan-results-storage-dir $scan_results_storage_dir \
-    --package-id $package_id \
-    --create-hierarchical-dirs \
-    --generate-path-excludes \
-    --output-dir $ort_config_package_configuration_dir \
-    --force-overwrite
+
+  create_package_configuration $package_id
+
   exit 0
 fi
 

--- a/orthw
+++ b/orthw
@@ -411,6 +411,13 @@ ort() {
   $ort $ort_options "$@"
 }
 
+offending_packages() {
+  orth list-packages \
+    --ort-file $evaluation_result_file \
+    --offending-only \
+    --offending-severities ERROR
+}
+
 orth() {
   export ORTH_OPTS="$orth_jvm_options"
 
@@ -817,13 +824,10 @@ fi
 
 if [ "$command" = "offending-packages" ] && [ "$#" -eq 1 ]; then
   require_initialized
-
   evaluate
 
-  orth list-packages \
-    --ort-file $evaluation_result_file \
-    --offending-only \
-    --offending-severities ERROR
+  offending_packages
+
   exit 0
 fi
 

--- a/orthw
+++ b/orthw
@@ -114,6 +114,7 @@ usage() {
   echo ""
   echo "  pc-clean <package-id>"
   echo "  pc-create <package-id>"
+  echo "  pc-create-offending"
   echo "  pc-export-curations <package-id> <source-code-dir>"
   echo "  pc-export-path-excludes <package-id> <source-code-dir>"
   echo "  pc-find <package-id>"
@@ -837,6 +838,21 @@ if [ "$command" = "pc-create" ] && [ "$#" -eq 2 ]; then
   package_id=$2
 
   create_package_configuration $package_id
+
+  exit 0
+fi
+
+
+if [ "$command" = "pc-create-offending" ] && [ "$#" -eq 1 ]; then
+  require_initialized
+  evaluate
+
+  packages_ids=$(offending_packages)
+
+  IFS=$'\n'
+  for id in $packages_ids; do
+    create_package_configuration $id
+  done
 
   exit 0
 fi

--- a/orthw
+++ b/orthw
@@ -824,6 +824,7 @@ if [ "$command" = "pc-create" ] && [ "$#" -eq 2 ]; then
     --scan-results-storage-dir $scan_results_storage_dir \
     --package-id $package_id \
     --create-hierarchical-dirs \
+    --generate-path-excludes \
     --output-dir $ort_config_package_configuration_dir \
     --force-overwrite
   exit 0


### PR DESCRIPTION
Modify an existing command to generate path excludes and add a new command for the bulk creation of package configurations for all (offending) packages.

Must be merged after https://github.com/oss-review-toolkit/ort/pull/5699.