### PR TITLE
orthw: Make the path exclude generation configurable

### DIFF
--- a/orthw
+++ b/orthw
@@ -237,6 +237,8 @@ create_package_configuration() {
       --package-id $package_id \
       --create-hierarchical-dirs \
       --generate-path-excludes \
+      --license-classifications-file $ort_config_license_classifications_file \
+      --non-offending-license-categories "$non_offending_license_categories" \
       --output-dir $ort_config_package_configuration_dir \
       --force-overwrite
 }

--- a/orthwconfig-template
+++ b/orthwconfig-template
@@ -44,6 +44,13 @@ scancode_version="30.1.0"
 enabled_advisors="osv"
 
 #
+# Comma-separated list of license categories within 'license-classifications.yml' for which no path excludes will be
+# created during package configuration generation (e.g. pc-create, pc-create-offending, pc-create-all commands). If set
+# to empty string, then path excludes will be generated for all file findings within a package.
+#
+non_offending_license_categories=""
+
+#
 # The template for the license classification request. Supported placeholders:
 # - <REPLACE_LICENSE_ID>
 # - <REPLACE_LICENSE_URL>


### PR DESCRIPTION
The path exclude generation optionally does not generate excludes for files and directories which only have non-offending license findings, see also [1].

Make use of that from `orthw` and add a corresponding configuration option to the configuration file.

[1] https://github.com/oss-review-toolkit/ort/pull/5854

Note: **Must be merged after** https://github.com/oss-review-toolkit/ort/pull/5854.

Part of https://github.com/oss-review-toolkit/ort/issues/5763.
