### PR TITLE
orthw: Re-align a directory name with `ort-config`

### DIFF
--- a/orthw
+++ b/orthw
@@ -46,7 +46,7 @@ ort_config_package_configuration_dir="$configuration_home/package-configurations
 ort_config_package_curations_dir="$configuration_home/curations"
 ort_config_resolutions_file="$configuration_home/resolutions.yml"
 ort_config_rules_file="$configuration_home/evaluator-rules/src/main/resources/example.rules.kts"
-ort_config_custom_license_texts_dir="$configuration_home/custom-licenses"
+ort_config_custom_license_texts_dir="$configuration_home/custom-license-texts"
 
 ########################################
 # Exports (repository) files:


### PR DESCRIPTION
The custom license texts directory has been renamed, see [1].

[1] https://github.com/oss-review-toolkit/ort-config/pull/68
