### PR TITLE
orthw: Extend the configuration for the path exclude generation

### DIFF
--- a/orthw
+++ b/orthw
@@ -237,6 +237,7 @@ create_package_configuration() {
       --generate-path-excludes \
       --license-classifications-file $ort_config_license_classifications_file \
       --non-offending-license-categories "$non_offending_license_categories" \
+      --non-offending-license-ids "$non_offending_license_ids" \
       --output-dir $ort_config_package_configuration_dir \
       --force-overwrite
 }

--- a/orthwconfig-template
+++ b/orthwconfig-template
@@ -45,10 +45,18 @@ enabled_advisors="osv"
 
 #
 # Comma-separated list of license categories within 'license-classifications.yml' for which no path excludes will be
-# created during package configuration generation (e.g. pc-create, pc-create-offending, pc-create-all commands). If set
-# to empty string, then path excludes will be generated for all file findings within a package.
+# created during package configuration generation (e.g. pc-create, pc-create-offending, pc-create-all commands). If
+# no non-offending license IDs and categories are defined, then path excludes will be generated for all file findings
+# within a package.
 #
 non_offending_license_categories=""
+
+#
+# Comma-separated list of license IDs for which no path excludes will be created during package configuration generation
+# (e.g. pc-create, pc-create-offending, pc-create-all commands). If non non-offending license IDs and categories are
+# defined, then path excludes will be generated for all file findings within a package.
+#
+non_offending_license_ids=""
 
 #
 # The template for the license classification request. Supported placeholders:


### PR DESCRIPTION
This allows skipping the generation of excludes for arbitrary license IDs or for NOASSERTION.

Note: must be merged after https://github.com/oss-review-toolkit/ort/pull/5995.