### PR TITLE
orthw: Change Shebang to use bash from $PATH

### DIFF
--- a/orthw
+++ b/orthw
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ########################################
 # Required configuration:


### PR DESCRIPTION
`bash` may not always be located at `/bin/bash`. Use the one on $PATH instead.
This change makes it possible to use the script on macOS where `/bin/bash` is stuck to version 3.2.57, in which `readarray` is not available. By using `bash` from $PATH a newer version which was installed manually can be used.