### PR TITLE
orthw: Re-align the filename of `how-to-fix-text-provider.kts`

### DIFF
--- a/orthw
+++ b/orthw
@@ -40,7 +40,7 @@ temp_dir="$dot_dir/tmp"
 #
 ort_config_copyright_garbage_file="$configuration_home/copyright-garbage.yml"
 ort_config_custom_license_texts_dir="$configuration_home/custom-license-texts"
-ort_config_how_to_fix_text_provider_script="$configuration_home/how-to-fix-text-provider.kts"
+ort_config_how_to_fix_text_provider_script="$configuration_home/reporter.how-to-fix-text-provider.kts"
 ort_config_license_classifications_file="$configuration_home/license-classifications.yml"
 ort_config_notice_templates_dir="$configuration_home/text-templates"
 ort_config_package_configurations_dir="$configuration_home/package-configurations"


### PR DESCRIPTION
Align the filename with the renaming in [1].

[1] https://github.com/oss-review-toolkit/ort-config/pull/126

