### PR TITLE
chore(orthw): Also delete the scan storage dir during init

### DIFF
--- a/orthw
+++ b/orthw
@@ -359,6 +359,7 @@ init() {
   local target_url=$1
 
   rm -f $evaluation_md5_sum_file
+  rm -rf $scan_results_storage_dir
   mkdir -p $dot_dir
   echo "$target_url" > $target_url_file
 


### PR DESCRIPTION
Ensure that the storage only contains the files corresponding to the ORT file the directory is (re-)initialized with.
