### PR TITLE
fix(orthw): Re-apply the resolutions in the reporter stage

### DIFF
--- a/orthw
+++ b/orthw
@@ -476,6 +476,7 @@ report() {
     --ort-file $evaluation_result_file \
     --output-dir $temp_dir \
     --report-formats $report_formats \
+    --refresh-resolutions \
     --repository-configuration-file $repository_configuration_file \
     --resolutions-file $ort_config_resolutions_file \
     -O SpdxDocument=output.file.formats=json,yaml \


### PR DESCRIPTION
As of [1][2], one has to provide `--refresh-resolutions` in order to make ORT consume the resolutions provided via `--resolutions-file`. If that flag is absent, ORT ignores the provided resolution in case the resolved configuration within the ORT file already contains resolutions.

So, provide that flag to ensure the resolutions get applied in the reporter stage.

[1] https://github.com/oss-review-toolkit/ort/commit/80605dc20495756c72df03179dcce6b5fba8d5ca
[2] https://github.com/oss-review-toolkit/ort/commit/ab99cdc8853a128df05207b88afbd2b76588f111
