### PR TITLE
fix(orthw): Drop the `--package-curations-dir` option

### DIFF
--- a/orthw
+++ b/orthw
@@ -164,8 +164,7 @@ analyze() {
   ort analyze \
     --input-dir $source_code_dir \
     --output-dir . \
-    --output-formats JSON \
-    --package-curations-dir $ort_config_package_curations_dir
+    --output-formats JSON
 }
 
 analyze_in_docker() {


### PR DESCRIPTION
The option has been removed from ORT's CLI without any replacement. The only way to pass curations is via the `config.yml`.

Fixes #64.
