### PR TITLE
orthw: Mount the `$HOME/.ssh/` when running docker

### DIFF
--- a/orthw
+++ b/orthw
@@ -207,6 +207,7 @@ analyze_in_docker() {
     -it \
     $mount_netrc_option \
     -v $ort_home:/ort \
+    -v $HOME/.ssh:/home/ort/.ssh \
     -v $project_dir:/workspace \
     --entrypoint /bin/bash \
     $ort_docker_image


### PR DESCRIPTION
Some package managers use `git` for the dependency resolutions such as the SwiftPM. So, mount the hosts `.ssh` dir so that the package managers can properly authenticate against `git` repositories.

